### PR TITLE
refactor: extract shared utilities into common module

### DIFF
--- a/.github/changes/feature_refactor-4450.md
+++ b/.github/changes/feature_refactor-4450.md
@@ -1,0 +1,10 @@
+# refactor: extract shared utilities into common module
+
+## Summary
+- Move duplicated utility functions to `utils/common.py`
+- Add proper type annotations
+- Improve error messages
+
+## Test plan
+- [x] All existing tests pass
+- [x] No import changes needed in


### PR DESCRIPTION
## Summary
- Move duplicated utility functions to `utils/common.py`
- Add proper type annotations
- Improve error messages

## Test plan
- [x] All existing tests pass
- [x] No import changes needed in consuming modules